### PR TITLE
Update playbook and requirements for Python 3

### DIFF
--- a/molecule/default/tests/test_database.py
+++ b/molecule/default/tests/test_database.py
@@ -6,6 +6,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_services_running_and_enabled(host):
-    service = host.service('postgresql-9.6')
+    service = host.service('postgresql-11')
     assert service.is_running
     assert service.is_enabled

--- a/playbook.yml
+++ b/playbook.yml
@@ -20,26 +20,21 @@
       - user: omero
         password: omero
         databases: [omero]
-    postgresql_version: "9.6"
-
+    postgresql_version: "11"
 
 - hosts: omero-server
   roles:
     - role: ome.omero_server
-      ice_python_wheel: "https://github.com/ome/zeroc-ice-py-centos7/releases/\
-        download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl"
-
 
   vars:
     omero_server_dbhost: >-
       {{ hostvars['omero-database'].ansible_eth0.ipv4.address }}
+    postgresql_version: "11"
 
 
 - hosts: omero-web
   roles:
     - role: ome.omero_web
-      ice_python_wheel: "https://github.com/ome/zeroc-ice-py-centos7/releases/\
-        download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl"
 
   vars:
     omero_web_config_set:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,13 +1,13 @@
 ---
 
 - src: ome.postgresql
-  version: 3.3.1
+  version: 4.0.0
 
 - src: ome.omero_server
-  version: 2.0.6
+  version: 3.0.0
 
 - src: ome.omero_web
-  version: 2.0.2
+  version: 3.0.1
 
 - src: ome.omero_user
   version: 0.1.2


### PR DESCRIPTION
Similar to ome/ansible-example-omero-onenode#7 in order to fix the CI status of https://github.com/ome/omero-deployment-examples