### PR TITLE
Add ome.basedeps in the omero-web role

### DIFF
--- a/molecule/centos7/molecule.yml
+++ b/molecule/centos7/molecule.yml
@@ -23,7 +23,6 @@ provisioner:
   lint:
     name: ansible-lint
   playbooks:
-    prepare: ../resources/prepare.yml
     converge: ../../playbook.yml
 scenario:
   name: centos7

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -1,7 +1,0 @@
----
-- hosts: omero-web
-  tasks:
-    - name: Install curl for tests
-      become: true
-      package:
-        name: curl

--- a/molecule/ubuntu1804/molecule.yml
+++ b/molecule/ubuntu1804/molecule.yml
@@ -29,7 +29,6 @@ provisioner:
   lint:
     name: ansible-lint
   playbooks:
-    prepare: ../resources/prepare.yml
     converge: ../../playbook.yml
 scenario:
   name: ubuntu1804

--- a/molecule/ubuntu2004/molecule.yml
+++ b/molecule/ubuntu2004/molecule.yml
@@ -29,7 +29,6 @@ provisioner:
   lint:
     name: ansible-lint
   playbooks:
-    prepare: ../resources/prepare.yml
     converge: ../../playbook.yml
 scenario:
   name: ubuntu2004

--- a/playbook.yml
+++ b/playbook.yml
@@ -40,6 +40,7 @@
 
 - hosts: omero-web
   roles:
+    - role: ome.basedeps
     - role: ome.omero_web
 
   vars:


### PR DESCRIPTION
Since `ome.basedeps` now installs `curl` which is a requirement for the Molecule Web tests, this PR implements a  change similar to other example playbook repositories - see https://github.com/sbesson/ansible-example-omero-onenode/commit/f3e740b53690d86f2d912684308b97851b4c214f.

The main difference for the three nodes configuration is that `ome.basedeps` is not a direct dependency of `ome.omero_web` and needs to be specified explicitly either in the deployment playbook or in the `prepare` playbook as a replacement of the manual `curl` installation.

This might add some unnecessary complexity to the playbook but opening for feedback