### PR TITLE
Cross-host facts. Modern hosts. No firewall.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -28,12 +28,23 @@
     - role: ome.iptables_raw
 
   tasks:
-    - name: Iptables internal hosts allow all
+    # Allow:
+    # - all established/related in/out
+    # - all internal localhost connections
+    # - all internal traffic
+    # - ICMP echo (ping)
+    # - ssh incoming connections
+    # - server to database connection
+    - name: Iptables allow server to database connection
       become: yes
       iptables_raw_25:
         name: database_accept
         keep_unmanaged: no
         rules: |
+          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          -A INPUT -i lo -j ACCEPT
+          -A INPUT -p icmp --icmp-type echo-request -j ACCEPT
           -A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
           -A INPUT -p tcp --dport 5432 -s {{ omero_server_address }} -j ACCEPT          
         state: present
@@ -57,7 +68,6 @@
 - hosts: omero_server
   roles:
     - role: ome.omero_server
-    - role: ome.iptables_raw
 
   vars:
     omero_server_dbhost: "{{ omero_database_address }}"
@@ -75,9 +85,7 @@
       omero.web.server_list:
         - ["{{ omero_server_address }}", 4064, omero]
 
-
 - hosts: omero_server omero_web
-
   roles:
     - role: ome.iptables_raw
 
@@ -88,7 +96,7 @@
     # - all internal traffic
     # - ICMP echo (ping)
     # - ssh incoming connections
-    # - Public IDR ports
+    # - Public omero ports
     - name: Iptables ssh and related
       become: yes
       iptables_raw_25:
@@ -100,33 +108,7 @@
           -A INPUT -i lo -j ACCEPT
           -A INPUT -p icmp --icmp-type echo-request -j ACCEPT
           -A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
-          -A INPUT -p tcp -m multiport --dports {{ idr_external_tcp_ports | join(',' ) }} -j ACCEPT
+          -A INPUT -p tcp -m multiport --dports 80,443,4063,4064 -j ACCEPT
         state: present
         # Highest priority
         weight: 0
-
-    # Use a low priority REJECT rule so that clients can detect when
-    # they've been rejected
-    # The alternative of setting a default DROP policy will leave them
-    # hanging until they timeout, though this may be preferable for public
-    # servers:
-    # http://www.chiark.greenend.org.uk/~peterb/network/drop-vs-reject
-    - name: Iptables default
-      become: yes
-      iptables_raw_25:
-        name: default_reject
-        rules: |
-          -A INPUT -j REJECT
-          -A FORWARD -j REJECT
-          -A OUTPUT -j ACCEPT
-        state: present
-        # Lowest priority
-        weight: 99
-
-  vars:
-    idr_external_tcp_ports:
-      - 80
-      - 443
-      - 4063
-      - 4064
-      - "14060:14079"

--- a/playbook.yml
+++ b/playbook.yml
@@ -10,7 +10,36 @@
       include_vars: "{{ ansible_facts['os_family'] | lower }}.yml"
       when: ansible_facts['os_family'] == "Debian"
 
-- hosts: omero-database
+# gather cross-host vars
+- hosts: all
+  tasks:
+    - name: Get omero IP addresses
+      set_fact:
+        omero_database_address: >-
+          {{ hostvars[groups['omero_database'][0]].ansible_default_ipv4.address }}
+        omero_server_address: >-
+            {{ hostvars[groups['omero_server'][0]].ansible_default_ipv4.address }}
+
+# turn off firewall for internal hosts (not for production!)
+- hosts: all
+  roles:
+    - role: ome.iptables_raw
+
+  tasks:
+    - name: Iptables internal hosts allow all
+      become: yes
+      iptables_raw_25:
+        name: default_accept
+        keep_unmanaged: no
+        rules: |
+          -A INPUT -j ACCEPT
+          -A FORWARD -j ACCEPT
+          -A OUTPUT -j ACCEPT
+        state: present
+        # Highest priority
+        weight: 0
+
+- hosts: omero_database
   roles:
     - role: ome.postgresql
 
@@ -28,17 +57,17 @@
         databases: [omero]
     postgresql_version: "11"
 
-- hosts: omero-server
+- hosts: omero_server
   roles:
     - role: ome.omero_server
 
   vars:
-    omero_server_dbhost: >-
-      {{ hostvars['omero-database'].ansible_eth0.ipv4.address }}
+    omero_server_dbhost: "{{ omero_database_address }}"
     postgresql_version: "11"
+    omero_server_dbuser: omero
+    omero_server_dbpassword: omero
 
-
-- hosts: omero-web
+- hosts: omero_web
   roles:
     - role: ome.basedeps
     - role: ome.omero_web
@@ -46,5 +75,4 @@
   vars:
     omero_web_config_set:
       omero.web.server_list:
-        - ["{{ hostvars['omero-server'].ansible_eth0.ipv4.address }}",
-           4064, omero]
+        - ["{{ omero_server_address }}", 4064, omero]

--- a/playbook.yml
+++ b/playbook.yml
@@ -19,29 +19,26 @@
           {{ hostvars[groups['omero_database'][0]].ansible_default_ipv4.address }}
         omero_server_address: >-
             {{ hostvars[groups['omero_server'][0]].ansible_default_ipv4.address }}
+        omero_web_address: >-
+            {{ hostvars[groups['omero_web'][0]].ansible_default_ipv4.address }}
 
-# turn off firewall for internal hosts (not for production!)
-- hosts: all
+- hosts: omero_database
   roles:
+    - role: ome.postgresql
     - role: ome.iptables_raw
 
   tasks:
     - name: Iptables internal hosts allow all
       become: yes
       iptables_raw_25:
-        name: default_accept
+        name: database_accept
         keep_unmanaged: no
         rules: |
-          -A INPUT -j ACCEPT
-          -A FORWARD -j ACCEPT
-          -A OUTPUT -j ACCEPT
+          -A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
+          -A INPUT -p tcp --dport 5432 -s {{ omero_server_address }} -j ACCEPT          
         state: present
         # Highest priority
         weight: 0
-
-- hosts: omero_database
-  roles:
-    - role: ome.postgresql
 
   vars:
     postgresql_server_listen: "'*'"
@@ -60,6 +57,7 @@
 - hosts: omero_server
   roles:
     - role: ome.omero_server
+    - role: ome.iptables_raw
 
   vars:
     omero_server_dbhost: "{{ omero_database_address }}"
@@ -76,3 +74,59 @@
     omero_web_config_set:
       omero.web.server_list:
         - ["{{ omero_server_address }}", 4064, omero]
+
+
+- hosts: omero_server omero_web
+
+  roles:
+    - role: ome.iptables_raw
+
+  tasks:
+    # Allow:
+    # - all established/related in/out
+    # - all internal localhost connections
+    # - all internal traffic
+    # - ICMP echo (ping)
+    # - ssh incoming connections
+    # - Public IDR ports
+    - name: Iptables ssh and related
+      become: yes
+      iptables_raw_25:
+        name: default_and_omero_external
+        keep_unmanaged: no
+        rules: |
+          -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+          -A INPUT -i lo -j ACCEPT
+          -A INPUT -p icmp --icmp-type echo-request -j ACCEPT
+          -A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
+          -A INPUT -p tcp -m multiport --dports {{ idr_external_tcp_ports | join(',' ) }} -j ACCEPT
+        state: present
+        # Highest priority
+        weight: 0
+
+    # Use a low priority REJECT rule so that clients can detect when
+    # they've been rejected
+    # The alternative of setting a default DROP policy will leave them
+    # hanging until they timeout, though this may be preferable for public
+    # servers:
+    # http://www.chiark.greenend.org.uk/~peterb/network/drop-vs-reject
+    - name: Iptables default
+      become: yes
+      iptables_raw_25:
+        name: default_reject
+        rules: |
+          -A INPUT -j REJECT
+          -A FORWARD -j REJECT
+          -A OUTPUT -j ACCEPT
+        state: present
+        # Lowest priority
+        weight: 99
+
+  vars:
+    idr_external_tcp_ports:
+      - 80
+      - 443
+      - 4063
+      - 4064
+      - "14060:14079"


### PR DESCRIPTION
I fixed a few things on the omero-three-node deployment sample. This worked for me with three freshly installed Centos 7 VMs. Fixes include:
- Ansible now prefers underscores to dashes in host names, `omero-database` => `omero_database` etc
- hostvars are not available for hosts outside of the current `-hosts:` block. So made a common block to gather connection addresses.
- Gathering hostvars from the first host in a group works better in my hands. Also, used the ansible_default_ipv4 address.
- Centos7 firewall blocks cross-host traffic. Turned off the firewalls for these internal connection through the ome.iptables_raw role. Future versions should specifically allow psql, omero, and web traffic on each specific host type via ome.iptables_raw or ansible.posix.firewalld rather than this blanket firewall turn-off.
- The omero-server needs the psql user and password to connect to the remote database. I'm not sure how secure this user:password combination of omero:omero will work now that the database and omero-server on on different machines.